### PR TITLE
modifying materialization strategy for `my_second_dbt_model`

### DIFF
--- a/models/example/my_second_dbt_model.sql
+++ b/models/example/my_second_dbt_model.sql
@@ -1,6 +1,8 @@
 
 -- Use the `ref` function to select from other models
 
+{{ config(materialized='table') }}
+
 select *
 from {{ ref('my_first_dbt_model') }}
 where id = 1


### PR DESCRIPTION
Result of second model is currently materialized as a view. 
<img width="292" alt="image" src="https://user-images.githubusercontent.com/6015305/209585681-3e1a5ad3-2600-4dda-ba63-692295a7007f.png">

This PR changes the materialization strategy to a table
<img width="314" alt="image" src="https://user-images.githubusercontent.com/6015305/209585740-a2180055-c446-4b38-b237-ddc0245bb1a6.png">
